### PR TITLE
Stairs: add firstAndLastStepColorized property

### DIFF
--- a/src/Stairs.ts
+++ b/src/Stairs.ts
@@ -130,5 +130,5 @@ export const StairsSchema = createSchemaInstance('Stairs', {
     accessibility: {
       description: t`Do the stairs have first and last step colorized?`
     }
-  },
+  }
 });

--- a/src/Stairs.ts
+++ b/src/Stairs.ts
@@ -46,6 +46,11 @@ export interface Stairs {
    * detectable with the touch of a foot or sweep of a cane.
    */
   hasTactileSafetyStrips?: boolean;
+  /**
+   * `true` if first and last step of the stair is colorized in a way, so that people with visual impairment can 
+   * recognize it easily.
+   */
+  firstAndLastStepColorized?: boolean;
 }
 
 export const StairsSchema = createSchemaInstance('Stairs', {
@@ -118,5 +123,12 @@ export const StairsSchema = createSchemaInstance('Stairs', {
   'alternativeMobileEquipmentIds.$': {
     type: String,
     label: t`accessibility.cloud Equipment ID`
-  }
+  },
+  firstAndLastStepColorized: {
+    type: Boolean,
+    optional: true,
+    accessibility: {
+      description: t`Do the stairs have first and last step colorized?`
+    }
+  },
 });


### PR DESCRIPTION
This pull adds the firstAndLastStepColorized property to `Stairs`. Initially introduced in #9.

I am sorry, but been currently very busy, so i didn't validate my changes (regarding to [CONTRIBUTING](https://github.com/sozialhelden/ac-format/blob/master/CONTRIBUTING.md)). Hope its OK and merge-able. Please adapt the texts, if you find more suitable English :)