### PR TITLE
outside/name can be object or string

### DIFF
--- a/src/transformers/transformKoboToA11y.ts
+++ b/src/transformers/transformKoboToA11y.ts
@@ -59,7 +59,7 @@ export type KoboResult = {
   'outside/entrance/picture': string;
   'outside/entrance/steps_count': string;
   'outside/entrance/steps_height': string;
-  'outside/name': string;
+  'outside/name': string | object;
   'inside/is_well_lit': YesNoResult;
   'inside/is_quiet': YesNoResult;
   'inside/toilet/basin_wheelchair_fits_belows': YesNoResult;


### PR DESCRIPTION
AC name type fix for Wheelmap-Kobo Source requires fix of a11yJSON transformKobo stream step to map name to object type 